### PR TITLE
Enable manual run for stable workflow

### DIFF
--- a/.github/workflows/docker-armv7.yml
+++ b/.github/workflows/docker-armv7.yml
@@ -1,0 +1,30 @@
+name: Build and Push ARMv7
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/arm/v7
+          push: true
+          tags: ghcr.io/${{ github.repository }}/speedtest-tracker:armv7

--- a/.github/workflows/laravel-stable.yml
+++ b/.github/workflows/laravel-stable.yml
@@ -3,6 +3,7 @@ name: Stable
 on:
   push:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   laravel-tests:


### PR DESCRIPTION
## Summary
- allow manual triggers for the Stable workflow
- add workflow to build and push armv7 docker image

## Testing
- `composer install --no-interaction --prefer-dist --no-scripts --ignore-platform-reqs` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68703ad90048832386ffcf4bf17cc471