### PR TITLE
Fix tests by defining default healthcheck UUID

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,5 +22,6 @@
     <server name="MAIL_MAILER" value="array"/>
     <server name="QUEUE_CONNECTION" value="sync"/>
     <server name="SESSION_DRIVER" value="array"/>
+    <server name="HEALTHCHECKS_UUID" value="00000000-0000-0000-0000-000000000000"/>
   </php>
 </phpunit>


### PR DESCRIPTION
## Summary
- set `HEALTHCHECKS_UUID` in phpunit config so healthcheck integration tests have a valid UUID

## Testing
- `composer install --ignore-platform-reqs` *(fails: return type errors due to PHP 8.3)*
- `./vendor/bin/phpunit` *(fails: vendor not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687045737c288323addb684e591eb4cf